### PR TITLE
Uses NPM over bower for markdown-it dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "ember-markdown-it",
   "dependencies": {
     "ember": "~2.9.0",
-    "ember-cli-shims": "0.1.3",
-    "markdown-it": "^6.0.0"
+    "ember-cli-shims": "0.1.3"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
-const path = require('path');
-const Funnel      = require('broccoli-funnel');
-const MergeTrees  = require('broccoli-merge-trees');
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
 
 'use strict';
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 /* jshint node: true */
+const path = require('path');
+const Funnel      = require('broccoli-funnel');
+const MergeTrees  = require('broccoli-merge-trees');
+
 'use strict';
 
 module.exports = {
@@ -7,7 +11,15 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/markdown-it/dist/markdown-it.min.js');
+    app.import('vendor/markdown-it.min.js');
     app.import('vendor/shims/markdown-it.js');
-  }
+  },
+
+  treeForVendor(vendorTree) {
+    var markdownItTree = new Funnel(path.join(this.project.root, 'node_modules', 'markdown-it', 'dist'), {
+      files: ['markdown-it.min.js'],
+    });
+
+    return new MergeTrees([vendorTree, markdownItTree]);
+  },
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
+    "markdown-it": "^8.3.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
As ember-cli is moving away from bower dependencies I thought is would good to move markdown-it to depend on NPM. 

I'm also in the process of moving [ember-freestyle](https://github.com/chrislopresto/ember-freestyle) to be used in a lazyloaded engine and we want to load all deps in that engine. Using bower would mean markdown-it be a dep of the engine consuming application